### PR TITLE
Add main entry for window plugin

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,7 @@
+function main() {
+  // Open the plugin's main UI window when activated
+  // plugin.openWindow opens the given HTML file in Eagle
+  plugin.openWindow('index.html');
+}
+
+module.exports = { main };

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "author": "icraigshaw",
   "type": "window",
-  "main": "app.js",
+  "main": "main.js",
   "window": "index.html"
 }


### PR DESCRIPTION
## Summary
- add a `main.js` entry that opens `index.html`
- reference the new entry script in `manifest.json`

## Testing
- `node -e "require('./main.js'); console.log('main loaded');"`

------
https://chatgpt.com/codex/tasks/task_b_68450b3cfa48832f8b184984b473c86b